### PR TITLE
Initialise elevation data extension variables.

### DIFF
--- a/include/vtzero/elevation_layer.hpp
+++ b/include/vtzero/elevation_layer.hpp
@@ -14,8 +14,8 @@ struct elevation_data {
     int32_t elevation_precision = 1;
     int32_t elevation_min = 0, elevation_max = 0;
     // some special data to reserve vertex/index buffers
-    uint32_t layer_coordinates_count;
-    uint32_t layer_triangles_count;
+    uint32_t layer_coordinates_count = 0;
+    uint32_t layer_triangles_count = 0;
 
     std::vector<int32_t> elevations;
 };


### PR DESCRIPTION
I was looking into MD5 differences between tiles generated on a branch and those on the mainline, even though the tile size was the same, and noticed that there were only a few bytes difference between the two. The diff was:

```diff
--- /tmp/main_terrain.decoded    2022-05-30 18:24:54.000000000 +0100
+++ /tmp/branch_terrain.decoded 2022-05-30 18:24:44.000000000 +0100
@@ -248,8 +248,8 @@
     4: 50
     8: 18446744073709549600
     9: 11387
-    20: 2495704452
-    21: 32537
+    20: 539458980
+    21: 32676
     10: 3865
     11: "..."
   }
```

Where `20` and `21` refer to the `layer_coordinates_count` and `layer_triangles_count`. As far as I can see, there wasn't a path through the code that was initialising these, so I think those values just represent uninitialised memory.